### PR TITLE
feat(monitoring): add Prometheus & Grafana

### DIFF
--- a/core-banking-service/build.gradle
+++ b/core-banking-service/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     //SPRING BOOT - TRACING
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
 

--- a/core-banking-service/src/main/resources/application-docker.yml
+++ b/core-banking-service/src/main/resources/application-docker.yml
@@ -1,0 +1,13 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+# reduce severity of logging noise when running in compose
+logging:
+  level:
+    root: INFO

--- a/docker-compose/docker-compose-support-apps.yml
+++ b/docker-compose/docker-compose-support-apps.yml
@@ -60,6 +60,8 @@ services:
     image: javatodev/internet-banking-config-server
     ports:
       - 8090:8090
+    volumes:
+      - ./internet-banking-config-server/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.8
@@ -68,9 +70,36 @@ services:
     image: javatodev/internet-banking-service-registry
     ports:
       - 8081:8081
+    volumes:
+      - ./internet-banking-service-registry/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.7
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    networks:
+      javatodev_ib_network:
+        ipv4_address: 172.25.0.20
+
+  grafana:
+    image: grafana/grafana:9.5.11
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    networks:
+      javatodev_ib_network:
+        ipv4_address: 172.25.0.21
 
 volumes:
   postgres_data:

--- a/docker-compose/docker-compose-support-apps.yml
+++ b/docker-compose/docker-compose-support-apps.yml
@@ -87,7 +87,7 @@ services:
         ipv4_address: 172.25.0.20
 
   grafana:
-    image: grafana/grafana:9.5.11
+    image: grafana/grafana:latest
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -152,7 +152,7 @@ services:
         ipv4_address: 172.25.0.20
 
   grafana:
-    image: grafana/grafana:9.5.11
+    image: grafana/grafana:latest
     container_name: grafana
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -63,6 +63,8 @@ services:
     container_name: internet-banking-config-server
     ports:
       - 8090:8090
+    volumes:
+      - ./internet-banking-config-server/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.8
@@ -72,6 +74,8 @@ services:
     container_name: internet-banking-service-registry
     ports:
       - 8081:8081
+    volumes:
+      - ./internet-banking-service-registry/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.7
@@ -82,6 +86,8 @@ services:
     ports:
       - 8082:8082
     entrypoint: ["./wait-for-it.sh", "internet-banking-service-registry:8081", "--timeout=50", "--", "./wait-for-it.sh", "internet-banking-config-server:8090", "--timeout=50", "--", "java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+    volumes:
+      - ./internet-banking-api-gateway/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.6
@@ -92,6 +98,8 @@ services:
     ports:
       - 8083:8083
     entrypoint: ["./wait-for-it.sh", "internet-banking-service-registry:8081", "--timeout=50", "--", "./wait-for-it.sh", "internet-banking-config-server:8090", "--timeout=50", "--", "./wait-for-it.sh", "mysql_core_db:3306", "--timeout=50", "--","java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+    volumes:
+      - ./internet-banking-user-service/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.5
@@ -102,6 +110,8 @@ services:
     ports:
       - 8084:8084
     entrypoint: ["./wait-for-it.sh", "internet-banking-service-registry:8081", "--timeout=50", "--", "./wait-for-it.sh", "internet-banking-config-server:8090", "--timeout=50", "--", "./wait-for-it.sh", "mysql_core_db:3306", "--timeout=50", "--","java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+    volumes:
+      - ./internet-banking-fund-transfer-service/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.4
@@ -112,6 +122,8 @@ services:
     ports:
       - 8085:8085
     entrypoint: ["./wait-for-it.sh", "internet-banking-service-registry:8081", "--timeout=50", "--", "./wait-for-it.sh", "internet-banking-config-server:8090", "--timeout=50", "--", "./wait-for-it.sh", "mysql_core_db:3306", "--timeout=50", "--","java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+    volumes:
+      - ./internet-banking-utility-payment-service/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.3
@@ -122,9 +134,38 @@ services:
     ports:
       - 8092:8092
     entrypoint: ["./wait-for-it.sh", "internet-banking-service-registry:8081", "--timeout=50", "--", "./wait-for-it.sh", "internet-banking-config-server:8090", "--timeout=50", "--", "./wait-for-it.sh", "mysql_core_db:3306", "--timeout=50", "--","java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+    volumes:
+      - ./core-banking-service/src/main/resources/application-docker.yml:/config/application-docker.yml:ro
     networks:
       javatodev_ib_network:
         ipv4_address: 172.25.0.2
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - 9090:9090
+    networks:
+      javatodev_ib_network:
+        ipv4_address: 172.25.0.20
+
+  grafana:
+    image: grafana/grafana:9.5.11
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    networks:
+      javatodev_ib_network:
+        ipv4_address: 172.25.0.21
 
 volumes:
   postgres_data:

--- a/docker-compose/grafana/dashboards/spring-boot-overview.json
+++ b/docker-compose/grafana/dashboards/spring-boot-overview.json
@@ -1,0 +1,24 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": null,
+    "title": "Spring Boot Overview",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "JVM Memory Used",
+        "targets": [
+          {
+            "expr": "jvm_memory_used_bytes",
+            "legendFormat": "{{instance}}",
+            "refId": "A"
+          }
+        ],
+        "gridPos": { "x": 0, "y": 0, "w": 24, "h": 9 }
+      }
+    ],
+    "schemaVersion": 16,
+    "version": 0
+  },
+  "overwrite": false
+}

--- a/docker-compose/grafana/provisioning/datasources/datasource.yml
+++ b/docker-compose/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker-compose/prometheus.yml
+++ b/docker-compose/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring-boot-services'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['internet-banking-api-gateway:8082', 'internet-banking-user-service:8083', 'internet-banking-fund-transfer-service:8084', 'internet-banking-utility-payment-service:8085', 'core-banking-service:8092', 'internet-banking-config-server:8090', 'internet-banking-service-registry:8081']

--- a/internet-banking-api-gateway/build.gradle
+++ b/internet-banking-api-gateway/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     //SPRING BOOT - TRACING
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
 

--- a/internet-banking-api-gateway/src/main/resources/application-docker.yml
+++ b/internet-banking-api-gateway/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO

--- a/internet-banking-config-server/build.gradle
+++ b/internet-banking-config-server/build.gradle
@@ -27,6 +27,8 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.cloud:spring-cloud-config-server'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/internet-banking-config-server/src/main/resources/application-docker.yml
+++ b/internet-banking-config-server/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO

--- a/internet-banking-fund-transfer-service/build.gradle
+++ b/internet-banking-fund-transfer-service/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     //SPRING BOOT - TRACING
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
 

--- a/internet-banking-fund-transfer-service/src/main/resources/application-docker.yml
+++ b/internet-banking-fund-transfer-service/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO

--- a/internet-banking-service-registry/build.gradle
+++ b/internet-banking-service-registry/build.gradle
@@ -21,6 +21,8 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/internet-banking-service-registry/src/main/resources/application-docker.yml
+++ b/internet-banking-service-registry/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO

--- a/internet-banking-user-service/build.gradle
+++ b/internet-banking-user-service/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     //SPRING BOOT - TRACING
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    // Prometheus metrics registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'io.github.openfeign:feign-micrometer'
 

--- a/internet-banking-user-service/src/main/resources/application-docker.yml
+++ b/internet-banking-user-service/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO

--- a/internet-banking-utility-payment-service/build.gradle
+++ b/internet-banking-utility-payment-service/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	//SPRING BOOT - TRACING
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	// Prometheus metrics registry
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'io.github.openfeign:feign-micrometer'
 

--- a/internet-banking-utility-payment-service/src/main/resources/application-docker.yml
+++ b/internet-banking-utility-payment-service/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    root: INFO


### PR DESCRIPTION
This PR adds Prometheus and Grafana support: micrometer prometheus registry in services, actuator docker profile, prometheus config, and grafana provisioning. Includes mounting application-docker.yml into containers to avoid rebuilds.